### PR TITLE
corey

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "express": "^4.18.2"
   }
 }


### PR DESCRIPTION
- Comment cleanup
- User Post Tags now populate when viewing the Index Route
- postsController.js | when a post is created, if it includes a tag, the tag is created if it's not already in the db, OR if it is, the tag's db id is assigned to the new post, so it can populate the tag info correctly
- Posts.js | Posts schema updated with likes
- added Procfile for Heroku
- edits to solve Heroku deployment error
- updated package.json to include express | why wasn't it there before?
